### PR TITLE
fix: base32 for ipfs:// urls and cidv1 everywhere

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,9 +98,10 @@ module.exports = function makeIPFSFetch ({ ipfs }) {
           path,
           content: body
         }, {
+          cidVersion: 1,
           wrapWithDirectory: true
         })
-        const cidHash = cidToString(cid)
+        const cidHash = cid.toString()
         const addedURL = `ipfs://${cidHash}${path}`
         return {
           statusCode: 200,
@@ -186,7 +187,7 @@ module.exports = function makeIPFSFetch ({ ipfs }) {
         }
 
         const { name } = await ipfs.name.publish(value, { name: keyName, signal })
-        const nameHash = cidToString(new CID(name))
+        const nameHash = new CID(name).toV1().toString('base36')
 
         const nameURL = `ipns://${nameHash}/`
         return {
@@ -249,8 +250,4 @@ function getMimeType (path) {
   let mimeType = mime.getType(path) || 'text/plain'
   if (mimeType.startsWith('text/')) mimeType = `${mimeType}; charset=utf-8`
   return mimeType
-}
-
-function cidToString (cid) {
-  return cid.toV1().toString('base36')
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "browser-run": "^8.0.0",
     "browserify": "^17.0.0",
-    "ipfs": "^0.50.2",
+    "ipfs-core": "^0.6.1",
     "standard": "^14.3.4",
     "tape": "^5.0.1"
   }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 global.Buffer = Buffer
 
 const test = require('tape')
-const IPFS = require('ipfs')
+const IPFS = require('ipfs-core')
 const makeIPFSFetch = require('./')
 
 const TEST_DATA = 'Hello World!'
@@ -20,7 +20,7 @@ test('Load a file via fetch', async (t) => {
 
     t.pass('Able to make create fetch instance')
 
-    const { cid } = await ipfs.add(TEST_DATA)
+    const { cid } = await ipfs.add(TEST_DATA, { cidVersion: 1 })
 
     const response = await fetch(`ipfs://${cid}`)
 
@@ -55,7 +55,7 @@ test('Load a range from a file', async (t) => {
 
     t.pass('Able to make create fetch instance')
 
-    const { cid } = await ipfs.add(TEST_DATA)
+    const { cid } = await ipfs.add(TEST_DATA, { cidVersion: 1 })
 
     const response = await fetch(`ipfs://${cid}`, { headers: { Range: 'bytes=0-4' } })
 
@@ -87,7 +87,7 @@ test('Get expected headers from HEAD', async (t) => {
 
     t.pass('Able to make create fetch instance')
 
-    const { cid } = await ipfs.add(TEST_DATA)
+    const { cid } = await ipfs.add(TEST_DATA, { cidVersion: 1 })
 
     const response = await fetch(`ipfs://${cid}`, { method: 'head' })
 
@@ -171,7 +171,7 @@ test('Resolve index.html from a directory', async (t) => {
     const results = await collect(ipfs.addAll([
       { path: '/index.html', content: TEST_DATA },
       { path: 'example/index.html', content: TEST_DATA }
-    ], { wrapWithDirectory: true }))
+    ], { wrapWithDirectory: true, cidVersion: 1 }))
 
     // The last element should be the directory itself
     const { cid } = results[results.length - 1]
@@ -236,16 +236,23 @@ test('POST a file into IPFS', async (t) => {
     t.ok(response, 'Got a response object')
     t.equal(response.status, 200, 'Got OK in response')
 
-    const cid = await response.text()
+    const ipfsUri = await response.text()
+    t.match(ipfsUri, /ipfs:\/\/\w+\/example.txt/, 'returned IPFS url with CID')
 
-    t.match(cid, /ipfs:\/\/\w+\/example.txt/, 'returned IPFS url with CID')
-
-    const fileResponse = await fetch(cid)
+    const fileResponse = await fetch(ipfsUri)
     t.equal(fileResponse.status, 200, 'Got OK in response')
 
     const text = await fileResponse.text()
-
     t.equal(text, TEST_DATA, 'Able to load POSTed file')
+
+    const { cid } = await ipfs.add({
+      path: 'example.txt',
+      content: TEST_DATA
+    }, {
+      cidVersion: 1,
+      wrapWithDirectory: true
+    })
+    t.equal(ipfsUri.match(/ipfs:\/\/([^/]+)/)[1], cid.toString('base32'), 'Matches cid from ipfs.add')
   } catch (e) {
     t.fail(e.message)
   } finally {
@@ -277,7 +284,8 @@ test('Publish and resolve IPNS', async (t) => {
 
     const ipnsURI = await publishResponse.text()
 
-    t.ok(ipnsURI, 'Got resulting IPNS url')
+    // base36 prefix is k https://github.com/multiformats/js-multibase/blob/ddd99e6d0d089d5d1209094f2e7a2a07d87729fb/src/constants.js#L43
+    t.ok(ipnsURI.startsWith('ipns://k'), 'Got base36 encoded IPNS url')
 
     const resolvedResponse = await fetch(ipnsURI, {
       headers: {


### PR DESCRIPTION
- make POST return a base32 encoded cidv1. (it was returning bsae36 which is valid, but surprising)
- default to using cidv1 everywhere.
- update to use the new ipfs-core module.

base36 is the right thing to use to respect the max authority length for ipns:// scheme urls. 
The assumption is folks should use base32 for CIDs in ipfs:// scheme urls, and it's the default output for cidv1.

The new ipfs-core modules has the same api as the `ipfs` module but doesn't include the cli and http-server code with it.

At time of writing the tests pass apart from the last one, which hangs. I think it's due to an unrelated bug https://github.com/ipfs/js-ipfs/issues/3692


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>