### PR TITLE
ESM rewrite, IPLD Schema support, IPLD Patch support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [ '16' ]
+        node: [ '19' ]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     name: Node ${{ matrix.node }}-${{matrix.os}} tests

--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ const DEFAULT_HEADERS = {
 }
 
 async function DEFAULT_ON_NOT_FOUND (request) {
-  console.log(request)
   return {
     status: 405,
     body: 'Method Not Supported'

--- a/index.js
+++ b/index.js
@@ -1,753 +1,781 @@
-const makeFetch = require('make-fetch')
-const parseRange = require('range-parser')
-const mime = require('mime/lite')
-const { CID } = require('multiformats/cid')
-const { base32 } = require('multiformats/bases/base32')
-const { base36 } = require('multiformats/bases/base36')
-const cbor = require('@ipld/dag-cbor')
+import { makeRoutedFetch } from 'make-fetch'
+import { IPLDURLSystem } from 'js-ipld-url-resolve'
+
+import parseRange from 'range-parser'
+import mime from 'mime/lite.js'
+
+import { exporter } from 'ipfs-unixfs-exporter'
+import { CID } from 'multiformats/cid'
+
+import { base32 } from 'multiformats/bases/base32'
+import { base36 } from 'multiformats/bases/base36'
+
 // Different from raw JSON. Determenistic
-const dagJSON = require('@ipld/dag-json')
-const Busboy = require('busboy')
-const { Readable } = require('stream')
-const { EventIterator } = require('event-iterator')
-const crypto = require('crypto')
-const posixPath = require('path').posix
-const { exporter } = require('ipfs-unixfs-exporter')
-const { IPLDURL } = require('js-ipld-url')
+import * as dagJSON from '@ipld/dag-json'
+import * as cbor from '@ipld/dag-cbor'
+
+import crypto from 'crypto'
+import { posix as posixPath } from 'path'
+
+import { EventIterator } from 'event-iterator'
 
 const bases = base32.decoder.or(base36.decoder)
 
 const IPFS_TIMEOUT = 30000
 const IPNS_TIMEOUT = 120000
-const SUPPORTED_METHODS = ['GET', 'HEAD', 'POST', 'PUT', 'DELETE']
 const SPECIAL_HOSTNAME = 'localhost'
 
-module.exports = function makeIPFSFetch ({
+const DEFAULT_HEADERS = {
+  'Content-Type': 'text/plain; charset=utf-8'
+}
+
+async function DEFAULT_ON_NOT_FOUND (request) {
+  console.log(request)
+  return {
+    status: 405,
+    body: 'Method Not Supported'
+  }
+}
+
+async function DEFAULT_RENDER_INDEX (url, files, fetch) {
+  return `
+<!DOCTYPE html>
+<title>Index of ${url.pathname}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<h1>Index of ${url.pathname}</h1>
+<ul>
+  <li><a href="../">../</a></li>
+  ${files.map((file) => `<li><a href="${file}">./${file}</a></li>`).join('\n')}
+</ul>
+`
+}
+
+export default function makeIPFSFetch ({
   ipfs,
-  ipfsTimeout = IPFS_TIMEOUT,
-  ipnsTimeout = IPNS_TIMEOUT
+  timeout = IPFS_TIMEOUT,
+  ipnsTimeout = IPNS_TIMEOUT,
+  onNotFound = DEFAULT_ON_NOT_FOUND,
+  renderIndex = DEFAULT_RENDER_INDEX,
+  defaultHeaders = DEFAULT_HEADERS,
+  writable = true
 }) {
-  return makeFetch(async ({ url, headers: reqHeaders, method, signal, body }) => {
-    const { hostname, pathname, protocol, searchParams } = new URL(url)
-    let ipfsPath = hostname ? hostname + pathname : pathname.slice(1)
+  const { router, fetch } = makeRoutedFetch({
+    onNotFound
+  })
+  const ipldSystem = new IPLDURLSystem({
+    getNode
+  })
 
-    const headers = {}
+  router.get('ipld://*/**', async ({ url, headers, signal }) => {
+    const accept = headers.get('Accept')
+    const format = new URL(url).searchParams.get('format')
 
-    headers.Allow = SUPPORTED_METHODS.join(', ')
+    const value = ipldSystem.resolve(url.href)
 
-    async function getStat (path) {
-      return exporter(path, ipfs.block, { signal, preload: false, timeout: ipfsTimeout })
+    if (format === 'dag-cbor' || accept === 'application/vnd.ipld.dag-cbor') {
+      return {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/vnd.ipld.dag-cbor'
+        },
+        body: cbor.encode(value)
+      }
     }
 
-    async function serveFile (path = ipfsPath) {
-      headers['Accept-Ranges'] = 'bytes'
+    return {
+      status: 200,
+      headers: {
+        'Content-Type': 'appliction/json'
+      },
+      body: dagJSON.encode(value)
+    }
+  })
 
-      // Probably a file
-      const isRanged = reqHeaders.Range || reqHeaders.range
-      const file = await getStat(path)
-      const { size } = file
-      const mimeName = searchParams.get('filename') || path
+  if (writable) {
+    router.post(`ipld://${SPECIAL_HOSTNAME}/**`, async (request) => {
+      const { headers, url, signal } = request
+      const contentType = headers.get('Content-Type')
+      const format = new URL(url).searchParams.get('format')
 
-      headers['Content-Type'] = getMimeType(mimeName)
+      const data = await request.arrayBuffer()
 
-      if (isRanged) {
-        const ranges = parseRange(size, isRanged)
-        if (ranges && ranges.length && ranges.type === 'bytes') {
-          const [{ start, end }] = ranges
-          const length = (end - start + 1)
-          headers['Content-Length'] = `${length}`
-          headers['Content-Range'] = `bytes ${start}-${end}/${size}`
-          return {
-            statusCode: 206,
-            headers,
-            data: ipfs.cat(path, { signal, offset: start, length, timeout: ipfsTimeout })
-          }
+      let decoded = null
+      let storeCodec = cbor
+
+      if (contentType === 'application/json') {
+        decoded = JSON.parse(data.toString('utf8'))
+        storeCodec = 'dag-json'
+      } else if (contentType === 'application/dag-json') {
+        decoded = dagJSON.decode(data)
+        storeCodec = 'dag-json'
+      } else if (contentType === 'application/vnd.ipld.dag-cbor') {
+        decoded = cbor.decode(data)
+        storeCodec = 'dag-cbor'
+      } else {
+        return {
+          // TODO: better status?
+          status: 400,
+          headers: defaultHeaders,
+          body: 'Unsupproted content-type, must be dag-cbor, or dag-json'
+        }
+      }
+
+      if (format) {
+        if (format === 'dag-json' || format === 'dag-cbor') {
+          storeCodec = format
         } else {
-          headers['Content-Length'] = `${size}`
           return {
-            statusCode: 200,
-            headers,
-            data: ipfs.cat(path, { signal, timeout: ipfsTimeout })
+          // TODO: better status?
+            status: 400,
+            headers: defaultHeaders,
+            body: 'Unsupproted format, must be dag-json or dag-cbor'
           }
+        }
+      }
+
+      const cid = await ipfs.dag.put(decoded, {
+        storeCodec,
+        timeout,
+        signal
+      })
+
+      const cidHash = cid.toV1().toString()
+      const addedURL = `ipld://${cidHash}/`
+
+      headers.Location = addedURL
+
+      return {
+        status: 201,
+        headers: {
+          ...defaultHeaders,
+          Location: addedURL
+        },
+        body: addedURL
+      }
+    })
+  }
+
+  if (writable) {
+    router.get('pubsub://*/', async ({ url, headers }) => {
+      const format = new URL(url).searchParams.get('format')
+      const accept = headers.get('Accept')
+      const topic = url.hostname
+
+      if (accept && accept.includes('text/event-stream')) {
+        const events = new EventIterator(({ push, fail }) => {
+          function handler ({ from, data, topicIDs: topics, seqno }) {
+            try {
+              const id = Buffer.from(seqno).toString('hex')
+              let formatted = null
+              if (format === 'json') {
+                formatted = JSON.parse(Buffer.from(data).toString('utf8'))
+              } else if (format === 'utf8') {
+                formatted = Buffer.from(data).toString('utf8')
+              } else {
+                formatted = Buffer.from(data).toString('base64')
+              }
+
+              const eventData = JSON.stringify({
+                from,
+                topics,
+                data: formatted
+              })
+
+              push(`id:${id}\ndata:${eventData}\n\n`)
+            } catch (e) {
+              push(`type:error\ndata:${e.stack}\n\n`)
+            }
+          }
+          ipfs.pubsub.subscribe(topic, handler).catch((e) => {
+            fail(e)
+          })
+          return () => ipfs.pubsub.unsubscribe(topic, handler)
+        })
+
+        return {
+          status: 200,
+          headers: {
+            'Content-Type': 'text/event-stream'
+          },
+          body: events
+        }
+      }
+
+      const id = await ipfs.id()
+      const subs = await ipfs.pubsub.ls()
+      const subscribed = subs.includes(topic)
+
+      const body = JSON.stringify({ id, topic, subscribed }, null, '\t')
+
+      return {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body
+      }
+    })
+
+    router.post('pubsub://*/', async (request) => {
+      const { url, signal } = request
+      const topic = url.hostname
+      const payload = await request.arrayBuffer()
+      // TODO: Handle oversized messages wihth 413
+      await ipfs.pubsub.publish(topic, payload, {
+        signal,
+        timeout
+      })
+
+      return {
+        status: 200
+      }
+    })
+  }
+
+  if (writable) {
+    router.get(`ipns://${SPECIAL_HOSTNAME}/`, async ({ url, signal }) => {
+      const key = new URL(url).searchParams.get('key')
+      const exists = await hasKey(key, signal)
+      if (!exists) {
+        return {
+          status: 404,
+          headers: defaultHeaders,
+          body: 'Key Not Found'
+        }
+      } else {
+        const keyURL = keyToURL(exists)
+        return {
+          status: 302,
+          headers: {
+            ...defaultHeaders,
+            Location: keyURL
+          },
+          body: keyURL
+        }
+      }
+    })
+    // TODO: Generate from headers somehow
+    router.post(`ipns://${SPECIAL_HOSTNAME}/`, async ({ url, signal }) => {
+      const key = new URL(url).searchParams.get('key')
+      // Localhost is used for generating keys
+      const exists = await hasKey(key, signal)
+      if (!exists) {
+        await genKey(key, signal)
+      }
+      const keyData = await hasKey(key, signal)
+      const keyURL = keyToURL(keyData)
+
+      return {
+        status: 201,
+        headers: {
+          Location: keyURL
+        }
+      }
+    })
+    router.delete(`ipns://${SPECIAL_HOSTNAME}/`, async ({ url, signal }) => {
+      const key = new URL(url).searchParams.get('key')
+      await ipfs.key.rm(key, {
+        signal,
+        timeout
+      })
+
+      return {
+        status: 200
+      }
+    })
+
+    router.post(`ipfs://${SPECIAL_HOSTNAME}/`, async (request) => {
+      const { headers, signal } = request
+      const contentType = headers.get('Content-Type') || ''
+      const isFormData = contentType.includes('multipart/form-data')
+      const isCAR = contentType.includes('application/vnd.ipld.car')
+
+      if (isCAR) {
+        const results = []
+        const importOpts = { timeout, pinRoots: true }
+        for await (const { root } of ipfs.dag.import(request.body, importOpts)) {
+          const { cid } = root
+
+          const cidHash = cid.toString()
+          const addedURL = `ipfs://${cidHash}/`
+
+          results.push(addedURL)
+        }
+
+        return {
+          status: 200,
+          headers: defaultHeaders,
+          body: results.join('\n')
+        }
+      }
+
+      const dir = '/ipfs/bafyaabakaieac/localhost'
+      const addedURLRaw = await uploadData(dir, request, isFormData, signal)
+      // Resolve the localhost thing back to the root CID
+      const { cid } = await ipfs.dag.resolve(addedURLRaw.replace('ipfs://', '/ipfs/'))
+
+      const cidHash = cid.toString()
+      const addedURL = `ipfs://${cidHash}/`
+
+      return {
+        status: 201,
+        headers: {
+          ...defaultHeaders,
+          Location: addedURL
+        },
+        body: addedURL
+      }
+    })
+
+    router.put(`ipfs://${SPECIAL_HOSTNAME}/`, onNotFound)
+    router.put('ipfs://*/**', async (request) => {
+      const { url, headers, signal } = request
+      const contentType = headers.get('Content-Type') || ''
+      const isFormData = contentType.includes('multipart/form-data')
+
+      const ipfsPath = urlToIPFSPath(url)
+
+      const addedURL = await uploadData(ipfsPath, request, isFormData, signal)
+
+      return {
+        status: 201,
+        headers: {
+          ...defaultHeaders,
+          Location: addedURL
+        },
+        body: addedURL
+      }
+    })
+
+    router.put(`ipns://${SPECIAL_HOSTNAME}/`, onNotFound)
+    router.put('ipns://**/**', async (request) => {
+      const { url, signal, headers } = request
+      const contentType = headers.get('Content-Type') || ''
+      const isFormData = contentType.includes('multipart/form-data')
+
+      let ipfsPath = urlToIPNSPath(url)
+      const split = ipfsPath.split('/')
+      const keyName = split[0]
+      const subpath = split.slice(1).join('/')
+
+      if (isFormData || subpath) {
+        // Resolve to current CID before writing over it
+        try {
+          ipfsPath = await resolveIPNS(keyName)
+          if (ipfsPath.startsWith('/ipfs/')) ipfsPath = ipfsPath.slice('/ipfs/'.length)
+          ipfsPath += `/${subpath}`
+        } catch (e) {
+          // console.error(e)
+          // If CID couldn't be resolved from the key, use the subpath
+          // TODO: Detect specific issues
+          ipfsPath = subpath
+        }
+
+        const addedURL = await uploadData(ipfsPath, request, isFormData, signal)
+        // We just want the new root CID, not the full path to the file
+        const cid = addedURL.slice('ipfs://'.length).split('/')[0]
+        const value = `/ipfs/${cid}/`
+
+        return updateIPNS(keyName, value)
+      }
+    })
+
+    router.post('ipns://*/', async (request) => {
+      const { url, signal } = request
+      const { hostname: keyName } = new URL(url)
+
+      const rawValue = await request.text()
+      const value = rawValue.replace(/^ipfs:\/\//, '/ipfs/').replace(/^ipns:\/\//, '/ipns/')
+
+      return updateIPNS(keyName, value, signal)
+    })
+
+    router.delete('ipfs://*/**', async ({ url, signal }) => {
+      const ipfsPath = urlToIPFSPath(url)
+
+      return deleteData(ipfsPath, signal)
+    })
+    router.delete('ipns://*/**', async ({ url, signal }) => {
+      let ipfsPath = urlToIPFSPath(url)
+      ipfsPath = await resolveIPNS(ipfsPath, signal)
+      return deleteData(ipfsPath, signal)
+    })
+  }
+
+  // These are all reserved domains for later use
+  router.head(`ipfs://${SPECIAL_HOSTNAME}/**`, onNotFound)
+  router.get(`ipfs://${SPECIAL_HOSTNAME}/**`, onNotFound)
+  router.head(`ipns://${SPECIAL_HOSTNAME}/`, onNotFound)
+  router.get(`ipns://${SPECIAL_HOSTNAME}/`, onNotFound)
+
+  router.head('ipfs://*/**', async ({ url, signal }) => {
+    const { searchParams } = new URL(url)
+    const ipfsPath = urlToIPFSPath(url)
+
+    return serveHead(ipfsPath, searchParams, signal)
+  })
+  router.head('ipns://*/**', async ({ url, signal }) => {
+    const { searchParams } = new URL(url)
+    let ipfsPath = urlToIPNSPath(url)
+    ipfsPath = await resolveIPNS(ipfsPath, signal)
+    return serveHead(ipfsPath, searchParams, signal)
+  })
+
+  router.get('ipfs://*/**', async ({ url, signal, headers }) => {
+    const { searchParams } = new URL(url)
+    const ipfsPath = urlToIPFSPath(url)
+
+    return serveGet(url, ipfsPath, searchParams, headers, signal)
+  })
+  router.get('ipns://*/**', async ({ url, signal, headers }) => {
+    const { searchParams } = new URL(url)
+    let ipfsPath = urlToIPNSPath(url)
+    ipfsPath = await resolveIPNS(ipfsPath, signal)
+    return serveGet(url, ipfsPath, searchParams, headers, signal)
+  })
+
+  async function serveGet (url, ipfsPath, searchParams, reqHeaders, signal) {
+    const format = searchParams.get('format')
+    const accept = reqHeaders.get('Accept') || ''
+    const expectedType = format || accept
+
+    const headers = { ...defaultHeaders }
+
+    if (expectedType === 'raw' || expectedType === 'application/vnd.ipld.raw') {
+      const body = await ipfs.block.get(ipfsPath, {
+        timeout,
+        signal
+      })
+
+      headers['Content-Type'] = 'application/vnd.ipld.raw'
+
+      return {
+        status: 200,
+        headers,
+        body
+      }
+    }
+
+    if (expectedType === 'car' || expectedType === 'application/vnd.ipld.car') {
+      const { cid } = await ipfs.dag.resolve(ipfsPath, {
+        timeout,
+        signal
+      })
+      // must resolve to a CID to export, paths not supported here
+      const body = ipfs.dag.export(cid, {
+        timeout,
+        signal
+      })
+
+      headers['Content-Type'] = 'application/vnd.ipld.car'
+
+      return {
+        status: 200,
+        headers,
+        body
+      }
+    }
+
+    const stat = await getStat(ipfsPath)
+
+    if (stat.type === 'directory') {
+      // Probably a directory
+
+      let body = null
+
+      try {
+        const stats = await collect(ipfs.ls(ipfsPath, { signal, timeout }))
+        const files = stats.map(({ name, type }) => (type === 'dir') ? `${name}/` : name)
+
+        if (files.includes('index.html')) {
+          if (!searchParams.has('noResolve')) {
+            return serveFile(posixPath.join(ipfsPath, 'index.html'), searchParams, reqHeaders, headers, signal)
+          }
+        }
+
+        if (accept.includes('text/html')) {
+          const page = await renderIndex(url, files, fetch)
+          headers['Content-Type'] = 'text/html; charset=utf-8'
+          body = page
+        } else {
+          const json = JSON.stringify(files, null, '\t')
+          headers['Content-Type'] = 'application/json; charset=utf-8'
+          body = json
+        }
+
+        return {
+          status: 200,
+          headers,
+          body
+        }
+      } catch {
+        return serveFile(ipfsPath, searchParams, reqHeaders, headers, signal)
+      }
+    } else {
+      return serveFile(ipfsPath, searchParams, reqHeaders, headers, signal)
+    }
+  }
+
+  async function serveHead (ipfsPath, searchParams, signal) {
+    const noResolve = searchParams.has('noResolve')
+
+    const stat = await getStat(ipfsPath)
+
+    if (stat.type === 'directory') {
+      // TODO: Something for directories?
+      if (!noResolve) {
+        const stats = await collect(ipfs.ls(ipfsPath, {
+          signal,
+          timeout
+        }))
+        const files = stats.map(({ name, type }) => (type === 'dir') ? `${name}/` : name)
+        if (files.includes('index.html')) {
+          ipfsPath = posixPath.join(ipfsPath, 'index.html')
+        } else {
+          return {
+            status: 200,
+            headers: defaultHeaders
+          }
+        }
+      }
+    }
+
+    const finalStat = await getStat(ipfsPath, signal)
+    const { size } = finalStat
+    const mimeName = searchParams.get('filename') || ipfsPath
+
+    return {
+      status: 200,
+      headers: {
+        ...defaultHeaders,
+        'Accept-Ranges': 'bytes',
+        'Content-Type': getMimeType(mimeName),
+        'Content-Length': `${size}`
+      }
+    }
+  }
+
+  async function serveFile (path, searchParams, reqHeaders, headers = { ...defaultHeaders }, signal) {
+    headers['Accept-Ranges'] = 'bytes'
+
+    // Probably a file
+    const isRanged = reqHeaders.get('Range') || ''
+    const file = await getStat(path)
+    const { size } = file
+    const mimeName = searchParams.get('filename') || path
+
+    headers['Content-Type'] = getMimeType(mimeName)
+
+    if (isRanged) {
+      const ranges = parseRange(size, isRanged)
+      if (ranges && ranges.length && ranges.type === 'bytes') {
+        const [{ start, end }] = ranges
+        const length = (end - start + 1)
+        headers['Content-Length'] = `${length}`
+        headers['Content-Range'] = `bytes ${start}-${end}/${size}`
+        return {
+          status: 206,
+          headers,
+          body: ipfs.cat(path, { signal, offset: start, length, timeout })
         }
       } else {
         headers['Content-Length'] = `${size}`
         return {
-          statusCode: 200,
+          status: 200,
           headers,
-          data: ipfs.cat(path, { signal, timeout: ipfsTimeout })
+          body: ipfs.cat(path, { signal, timeout })
         }
+      }
+    } else {
+      headers['Content-Length'] = `${size}`
+      return {
+        status: 200,
+        headers,
+        body: ipfs.cat(path, { signal, timeout })
+      }
+    }
+  }
+
+  async function getStat (path, signal) {
+    return exporter(path, ipfs.block, { signal, preload: false, timeout })
+  }
+
+  async function resolveIPNS (path, signal) {
+    const segments = ensureStartingSlash(path).split(/\/+/)
+    let mainSegment = segments[1]
+
+    if (!mainSegment.includes('.')) {
+      const keys = await ipfs.key.list({ signal, timeout: ipnsTimeout })
+      const keyForName = keys.find(({ name }) => name === mainSegment)
+      if (keyForName) {
+        mainSegment = keyForName.id + '/'
       }
     }
 
-    async function uploadData (path, content, isFormData) {
-      const tmpDir = makeTmpDir()
-      const { rootCID, relativePath } = cidFromPath(path)
+    const toResolve = `/ipns${ensureEndingSlash(ensureStartingSlash(mainSegment))}`
+    const resolved = await ipfs.resolve(toResolve, { signal, timeout: ipnsTimeout })
+    return [resolved, ...segments.slice(2)].join('/')
+  }
 
-      if (rootCID) {
-        await ipfs.files.cp(rootCID, tmpDir, {
-          parents: true,
-          cidVersion: 1,
-          signal,
-          timeout: ipfsTimeout
-        })
+  async function updateIPNS (keyName, value, signal) {
+    const existing = await hasKey(keyName)
+    if (!existing) {
+      await genKey(keyName, signal)
+    }
+
+    const finalName = existing ? existing.name : keyName
+
+    const publish = await ipfs.name.publish(value, {
+      allowOffline: true,
+      key: finalName,
+      signal,
+      timeout: ipnsTimeout
+    })
+    const { name: cid } = publish
+
+    const ipnsURL = `ipns://${cid}/`
+
+    return {
+      status: 201,
+      headers: {
+        ...defaultHeaders,
+        Location: ipnsURL
+      },
+      body: ipnsURL
+    }
+  }
+  async function genKey (keyName, signal) {
+    await ipfs.key.gen(keyName, {
+      signal,
+      type: 'rsa',
+      size: 2048,
+      timeout: ipnsTimeout
+    })
+  }
+
+  async function hasKey (keyName, signal) {
+    const keys = await ipfs.key.list({
+      signal,
+      timeout: ipnsTimeout
+    })
+
+    return keys.find(({ name, id }) => {
+      if (name === keyName) return true
+      try {
+        return (CID.parse(id, bases).toV1().toString(base36) === keyName)
+      } catch {
+        return false
       }
+    })
+  }
 
-      // Handle multipart formdata uploads
-      if (isFormData) {
-        const busboy = new Busboy({ headers: reqHeaders })
+  async function deleteData (ipfsPath, signal) {
+    const tmpDir = makeTmpDir()
+    const { rootCID, relativePath } = cidFromPath(ipfsPath)
 
-        const toUpload = new EventIterator(({ push, stop, fail }) => {
-          busboy.once('error', fail)
-          busboy.once('finish', stop)
+    if (rootCID) {
+      await ipfs.files.cp(rootCID, tmpDir, {
+        parents: true,
+        cidVersion: 1,
+        signal,
+        timeout
+      })
+    }
 
-          busboy.on('file', async (fieldName, fileData, fileName) => {
-            const finalPath = posixPath.join(tmpDir, relativePath, fileName)
-            try {
-              const result = ipfs.files.write(finalPath, Readable.from(fileData), {
-                cidVersion: 1,
-                parents: true,
-                truncate: true,
-                create: true,
-                rawLeaves: false,
-                signal,
-                timeout: ipfsTimeout
-              })
-              push(result)
-            } catch (e) {
-              fail(e)
-            }
-          })
+    await ipfs.files.rm(posixPath.join(tmpDir, relativePath), {
+      recursive: true,
+      cidVersion: 1,
+      signal,
+      timeout
+    })
 
-          // TODO: Does busboy need to be GC'd?
-          return () => {}
-        })
+    const { cid } = await ipfs.files.stat(tmpDir, {
+      hash: true,
+      signal,
+      timeout
+    })
 
-        // Parse body as a multipart form
-        // TODO: Readable.from doesn't work in browsers
-        Readable.from(content).pipe(busboy)
+    const cidHash = cid.toString()
+    const addedURL = `ipfs://${cidHash}/`
 
-        // toUpload is an async iterator of promises
-        // We collect the promises (all files are queued for upload)
-        // Then we wait for all of them to resolve
-        await Promise.all(await collect(toUpload))
-      } else {
-        // Node.js and browsers handle pathnames differently for IPFS URLs
-        const path = posixPath.join(tmpDir, ensureStartingSlash(stripEndingSlash(relativePath)))
+    return {
+      statusCode: 200,
+      headers: {
+        ...defaultHeaders,
+        Location: addedURL
+      },
+      body: addedURL
+    }
+  }
 
-        await ipfs.files.write(path, Readable.from(content), {
-          signal,
+  async function uploadData (ipfsPath, response, isFormData, signal) {
+    const tmpDir = makeTmpDir()
+    const { rootCID, relativePath } = cidFromPath(ipfsPath)
+
+    if (rootCID) {
+      await ipfs.files.cp(rootCID, tmpDir, {
+        parents: true,
+        cidVersion: 1,
+        signal,
+        timeout
+      })
+    }
+
+    if (isFormData) {
+      const formData = await response.formData()
+      const toWait = []
+
+      for (const [fieldName, fileData] of formData) {
+        // TODO: Should we filter by field name?
+        if (fieldName !== 'file') continue
+        // Must not be a file
+        if (!fileData.name) continue
+        const fileName = fileData.name
+        const finalPath = posixPath.join(tmpDir, relativePath, fileName)
+        const result = ipfs.files.write(finalPath, fileData, {
+          cidVersion: 1,
           parents: true,
           truncate: true,
           create: true,
-          rawLeaves: false,
-          cidVersion: 1,
-          timeout: ipfsTimeout
-        })
-      }
-
-      const { cid } = await ipfs.files.stat(tmpDir, { hash: true, signal, timeout: ipfsTimeout })
-
-      const cidHash = cid.toString()
-      const endPath = isFormData ? relativePath : stripEndingSlash(relativePath)
-      const addedURL = `ipfs://${cidHash}${ensureStartingSlash(endPath)}`
-
-      return addedURL
-    }
-
-    // Split out IPNS info and put it back together to resolve.
-    async function resolveIPNS (path) {
-      const segments = ensureStartingSlash(path).split(/\/+/)
-      let mainSegment = segments[1]
-
-      if (!mainSegment.includes('.')) {
-        const keys = await ipfs.key.list({ signal, timeout: ipnsTimeout })
-        const keyForName = keys.find(({ name }) => name === mainSegment)
-        if (keyForName) {
-          mainSegment = keyForName.id + '/'
-        }
-      }
-
-      const toResolve = `/ipns${ensureEndingSlash(ensureStartingSlash(mainSegment))}`
-      const resolved = await ipfs.resolve(toResolve, { signal, timeout: ipnsTimeout })
-      return [resolved, ...segments.slice(2)].join('/')
-    }
-
-    async function genKey (keyName) {
-      await ipfs.key.gen(keyName, {
-        signal,
-        type: 'rsa',
-        size: 2048,
-        timeout: ipnsTimeout
-      })
-    }
-
-    async function hasKey (keyName) {
-      const keys = await ipfs.key.list({ signal, timeout: ipnsTimeout })
-      return keys.find(({ name, id }) => {
-        if (name === keyName) return true
-        try {
-          return (CID.parse(id, bases).toV1().toString(base36) === keyName)
-        } catch {
-          return false
-        }
-      })
-    }
-
-    async function updateIPNS (keyName, value) {
-      const existing = await hasKey(keyName)
-      if (!existing) {
-        await genKey(keyName)
-      }
-
-      const finalName = existing ? existing.name : keyName
-
-      const publish = await ipfs.name.publish(value, {
-        allowOffline: true,
-        key: finalName,
-        signal,
-        timeout: ipnsTimeout
-      })
-      const { name: cid } = publish
-
-      const ipnsURL = `ipns://${cid}/`
-      headers.Location = ipnsURL
-
-      return {
-        statusCode: 201,
-        headers,
-        data: intoAsyncIterable(ipnsURL)
-      }
-    }
-
-    try {
-      if (protocol === 'ipld:') {
-        const { segments } = new IPLDURL(url)
-        const rawPath = segments.map(({ name }) => name).join('/')
-        ipfsPath = `/ipfs/${hostname}/${rawPath}`
-        if (method === 'GET') {
-          // TODO: resolve CID, match with Accept to see if block can be fetched instead
-          const { cid, remainderPath } = await ipfs.dag.resolve(ipfsPath)
-          const { value } = await ipfs.dag.get(cid, {
-            path: remainderPath,
-            timeout: ipfsTimeout,
-            signal
-          })
-
-          const format = searchParams.get('format')
-          const accept = reqHeaders.Accept || reqHeaders.accept
-
-          // TODO: Support stuff like dag-pb?
-          if (format === 'dag-cbor' || accept === 'application/vnd.ipld.dag-cbor') {
-            const encoded = cbor.encode(value)
-            headers['Content-Type'] = 'application/vnd.ipld.dag-cbor'
-            return {
-              statusCode: 200,
-              headers,
-              data: intoAsyncIterable(encoded)
-            }
-          } else {
-            // Assume JSON is wanted by default, makes it easy for viewing raw URLs / use with fetch
-            const encoded = dagJSON.encode(value)
-            // Use regular JSON mime type since it's easier to integrate with browsers and other tools
-            // Using vnd.ipld.dag-json causes chromim to attempt a download instead of viewing
-            headers['Content-Type'] = 'application/json'
-            return {
-              statusCode: 200,
-              headers,
-              data: intoAsyncIterable(encoded)
-            }
-          }
-        } else if (method === 'POST' && hostname === SPECIAL_HOSTNAME) {
-          const data = await collect(body)
-          const contentType = reqHeaders['Content-Type'] || reqHeaders['content-type']
-
-          let decoded = null
-          let storeCodec = cbor
-
-          if (contentType === 'application/json') {
-            decoded = JSON.parse(data.toString('utf8'))
-            storeCodec = 'dag-json'
-          } else if (contentType === 'application/dag-json') {
-            decoded = dagJSON.decode(data)
-            storeCodec = 'dag-json'
-          } else if (contentType === 'application/vnd.ipld.dag-cbor') {
-            decoded = cbor.decode(data)
-            storeCodec = 'dag-cbor'
-          } else {
-            return {
-              // TODO: better status?
-              statusCode: 400,
-              headers,
-              data: intoAsyncIterable('Unsupproted content-type, must be dag-cbor, or dag-json')
-            }
-          }
-
-          const format = searchParams.get('format')
-
-          if (format) {
-            if (format === 'dag-json' || format === 'dag-cbor') {
-              storeCodec = format
-            } else {
-              return {
-                // TODO: better status?
-                statusCode: 400,
-                headers,
-                data: intoAsyncIterable('Unsupproted format, must be dag-json or dag-cbor')
-              }
-            }
-          }
-
-          const cid = await ipfs.dag.put(decoded, {
-            storeCodec,
-            timeout: ipfsTimeout,
-            signal
-          })
-
-          const cidHash = cid.toV1().toString()
-          const addedURL = `ipld://${cidHash}/`
-
-          headers.Location = addedURL
-
-          return {
-            statusCode: 201,
-            headers,
-            data: intoAsyncIterable(addedURL)
-          }
-        } else {
-          return {
-            statusCode: 405,
-            headers,
-            data: intoAsyncIterable('Method Not Supported')
-          }
-        }
-      } else if (protocol === 'pubsub:') {
-        const topic = hostname
-        if (method === 'GET') {
-          const format = searchParams.get('format')
-          const accept = reqHeaders.Accept || reqHeaders.accept
-          if (accept && accept.includes('text/event-stream')) {
-            const events = new EventIterator(({ push, fail }) => {
-              function handler ({ from, data, topicIDs: topics, seqno }) {
-                try {
-                  const id = Buffer.from(seqno).toString('hex')
-                  let formatted = null
-                  if (format === 'json') {
-                    formatted = JSON.parse(Buffer.from(data).toString('utf8'))
-                  } else if (format === 'utf8') {
-                    formatted = Buffer.from(data).toString('utf8')
-                  } else {
-                    formatted = Buffer.from(data).toString('base64')
-                  }
-
-                  const eventData = JSON.stringify({
-                    from,
-                    topics,
-                    data: formatted
-                  })
-
-                  push(`id:${id}\ndata:${eventData}\n\n`)
-                } catch (e) {
-                  push(`type:error\ndata:${e.stack}\n\n`)
-                }
-              }
-              ipfs.pubsub.subscribe(topic, handler).catch((e) => {
-                fail(e)
-              })
-              return () => ipfs.pubsub.unsubscribe(topic, handler)
-            })
-
-            headers['Content-Type'] = 'text/event-stream'
-
-            return {
-              statusCode: 200,
-              headers,
-              data: events
-            }
-          } else {
-            const id = await ipfs.id()
-            const subs = await ipfs.pubsub.ls()
-            const subscribed = subs.includes(topic)
-
-            headers['Content-Type'] = 'application/json'
-
-            return {
-              statusCode: 200,
-              headers,
-              data: intoAsyncIterable(JSON.stringify({
-                id,
-                topic,
-                subscribed
-              }, null, '\t'))
-            }
-          }
-        } else if (method === 'POST') {
-          const payload = await collect(body)
-          // TODO: Handle oversized messages wihth 413
-          await ipfs.pubsub.publish(topic, payload, {
-            signal,
-            timeout: ipfsTimeout
-          })
-
-          return {
-            statusCode: 200,
-            headers,
-            data: intoAsyncIterable('')
-          }
-        }
-      } else if (hostname === SPECIAL_HOSTNAME) {
-        if (protocol === 'ipns:') {
-          const key = searchParams.get('key')
-
-          if (method === 'GET') {
-            const exists = await hasKey(key)
-            if (!exists) {
-              return {
-                statusCode: 404,
-                headers,
-                data: intoAsyncIterable('Key Not Found')
-              }
-            } else {
-              const keyURL = keyToURL(exists)
-              headers.Location = keyURL
-              return {
-                statusCode: 302,
-                headers,
-                data: intoAsyncIterable(keyURL)
-              }
-            }
-          } else if (method === 'POST') {
-            // Localhost is used for generating keys
-            const exists = await hasKey(key)
-            if (!exists) {
-              await genKey(key)
-            }
-            const keyData = await hasKey(key)
-            const keyURL = keyToURL(keyData)
-            headers.Location = keyURL
-
-            return {
-              statusCode: 201,
-              headers,
-              data: intoAsyncIterable('')
-            }
-          } else if (method === 'DELETE') {
-            await ipfs.key.rm(key, {
-              signal,
-              timeout: ipfsTimeout
-            })
-
-            return {
-              statusCode: 200,
-              headers,
-              body: intoAsyncIterable('')
-            }
-          } else {
-            return {
-              statusCode: 405,
-              headers,
-              data: intoAsyncIterable('Method Not Supported')
-            }
-          }
-        } else if (protocol === 'ipfs:') {
-          // POST but for the root
-          if (method === 'POST') {
-            const contentType = reqHeaders['Content-Type'] || reqHeaders['content-type']
-            const isFormData = contentType && contentType.includes('multipart/form-data')
-            const isCAR = contentType && contentType.includes('application/vnd.ipld.car')
-
-            if (isCAR) {
-              const results = []
-              const importOpts = { timeout: ipfsTimeout, pinRoots: true }
-              for await (const { root } of ipfs.dag.import(body, importOpts)) {
-                const { cid } = root
-
-                const cidHash = cid.toString()
-                const addedURL = `ipfs://${cidHash}/`
-
-                results.push(addedURL)
-              }
-
-              return {
-                statusCode: 200,
-                headers,
-                data: intoAsyncIterable(results.join('\n'))
-              }
-            }
-            const dir = '/ipfs/bafyaabakaieac/localhost'
-            const addedURLRaw = await uploadData(dir, body, isFormData, isCAR)
-            // Resolve the localhost thing back to the root CID
-            const { cid } = await ipfs.dag.resolve(addedURLRaw.replace('ipfs://', '/ipfs/'))
-
-            const cidHash = cid.toString()
-            const addedURL = `ipfs://${cidHash}/`
-
-            headers.Location = addedURL
-
-            return {
-              statusCode: 201,
-              headers,
-              data: intoAsyncIterable(addedURL)
-            }
-          } else {
-            return {
-              statusCode: 405,
-              headers,
-              data: intoAsyncIterable('Method Not Supported')
-            }
-          }
-        } else {
-          return {
-            statusCode: 405,
-            headers,
-            data: intoAsyncIterable('Protocol not supported for localhost')
-          }
-        }
-      } else if (protocol === 'ipfs:' && ((method === 'POST') || (method === 'PUT'))) {
-        // TODO: Deprecate using POST to upload data, use PUT instead
-        // Handle multipart formdata uploads
-        const contentType = reqHeaders['Content-Type'] || reqHeaders['content-type']
-        const isFormData = contentType && contentType.includes('multipart/form-data')
-
-        const addedURL = await uploadData(ipfsPath, body, isFormData)
-
-        headers.Location = addedURL
-
-        return {
-          statusCode: 201,
-          headers,
-          data: intoAsyncIterable(addedURL)
-        }
-      } else if (method === 'HEAD') {
-        if (protocol === 'ipns:') {
-          ipfsPath = await resolveIPNS(ipfsPath)
-        }
-        // TODO: Account for `?format` (can we even get content size without first downloading everything?
-        const stat = await getStat(ipfsPath)
-        if (stat.type === 'directory') {
-          // TODO: Something for directories?
-          if (!searchParams.has('noResolve')) {
-            const stats = await collect(ipfs.ls(ipfsPath, { signal, timeout: ipfsTimeout }))
-            const files = stats.map(({ name, type }) => (type === 'dir') ? `${name}/` : name)
-            if (files.includes('index.html')) {
-              ipfsPath = posixPath.join(ipfsPath, 'index.html')
-            } else {
-              return {
-                statusCode: 200,
-                headers,
-                data: intoAsyncIterable('')
-              }
-            }
-          }
-        }
-        const finalStat = await getStat(ipfsPath)
-        const { size } = finalStat
-        const mimeName = searchParams.get('filename') || ipfsPath
-
-        headers['Accept-Ranges'] = 'bytes'
-        headers['Content-Type'] = getMimeType(mimeName)
-        headers['Content-Length'] = `${size}`
-
-        return {
-          statusCode: 200,
-          headers,
-          data: intoAsyncIterable('')
-        }
-      } else if (method === 'GET') {
-        if (protocol === 'ipns:') {
-          ipfsPath = await resolveIPNS(ipfsPath)
-        }
-
-        const format = searchParams.get('format')
-        const accept = reqHeaders.Accept || reqHeaders.accept
-        const expectedType = format || accept
-
-        if (expectedType === 'raw' || expectedType === 'application/vnd.ipld.raw') {
-          const data = await ipfs.block.get(ipfsPath, {
-            timeout: ipfsTimeout,
-            signal
-          })
-
-          headers['Content-Type'] = 'application/vnd.ipld.raw'
-
-          return {
-            statusCode: 200,
-            headers,
-            data: intoAsyncIterable(data)
-          }
-        }
-
-        if (expectedType === 'car' || expectedType === 'application/vnd.ipld.car') {
-          const { cid } = await ipfs.dag.resolve(ipfsPath, {
-            timeout: ipfsTimeout,
-            signal
-          })
-          // must resolve to a CID to export, paths not supported here
-          const data = ipfs.dag.export(cid, {
-            timeout: ipfsTimeout,
-            signal
-          })
-
-          headers['Content-Type'] = 'application/vnd.ipld.car'
-
-          return {
-            statusCode: 200,
-            headers,
-            data
-          }
-        }
-
-        const stat = await getStat(ipfsPath)
-
-        if (stat.type === 'directory') {
-          // Probably a directory
-
-          let data = null
-
-          try {
-            const stats = await collect(ipfs.ls(ipfsPath, { signal, timeout: ipfsTimeout }))
-            const files = stats.map(({ name, type }) => (type === 'dir') ? `${name}/` : name)
-
-            if (files.includes('index.html')) {
-              if (!searchParams.has('noResolve')) {
-                return serveFile(posixPath.join(ipfsPath, 'index.html'))
-              }
-            }
-
-            const accept = reqHeaders.Accept || reqHeaders.accept
-            if (accept && accept.includes('text/html')) {
-              const page = `
-<!DOCTYPE html>
-<title>${url}</title>
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<h1>Index of ${pathname}</h1>
-<ul>
-  <li><a href="../">../</a></li>${files.map((file) => `
-  <li><a href="${file}">./${file}</a></li>
-`).join('')}
-</ul>
-`
-              headers['Content-Type'] = 'text/html; charset=utf-8'
-              data = page
-            } else {
-              const json = JSON.stringify(files, null, '\t')
-              headers['Content-Type'] = 'application/json; charset=utf-8'
-              data = json
-            }
-
-            return {
-              statusCode: 200,
-              headers,
-              data: intoAsyncIterable(data)
-            }
-          } catch {
-            return serveFile()
-          }
-        } else {
-          return serveFile()
-        }
-      } else if (protocol === 'ipns:' && ((method === 'POST') || (method === 'PUT'))) {
-        // Handle multipart formdata uploads
-        const contentType = reqHeaders['Content-Type'] || reqHeaders['content-type']
-        const isFormData = contentType && contentType.includes('multipart/form-data')
-
-        const split = ipfsPath.split('/')
-        const keyName = split[0]
-        const subpath = split.slice(1).join('/')
-
-        if (isFormData || subpath) {
-          // Resolve to current CID before writing over it
-          try {
-            ipfsPath = await resolveIPNS(keyName)
-            if (ipfsPath.startsWith('/ipfs/')) ipfsPath = ipfsPath.slice('/ipfs/'.length)
-            ipfsPath += `/${subpath}`
-          } catch (e) {
-            // console.error(e)
-            // If CID couldn't be resolved from the key, use the subpath
-            // TODO: Detect specific issues
-            ipfsPath = subpath
-          }
-
-          const addedURL = await uploadData(ipfsPath, body, isFormData)
-          // We just want the new root CID, not the full path to the file
-          const cid = addedURL.slice('ipfs://'.length).split('/')[0]
-          const value = `/ipfs/${cid}/`
-
-          return updateIPNS(keyName, value)
-        } else {
-          const rawValue = await collectString(body)
-          const value = rawValue.replace(/^ipfs:\/\//, '/ipfs/').replace(/^ipns:\/\//, '/ipns/')
-          return updateIPNS(keyName, value)
-        }
-      } else if (method === 'DELETE') {
-        if (protocol === 'ipns:') {
-          ipfsPath = await resolveIPNS(ipfsPath)
-        }
-
-        const tmpDir = makeTmpDir()
-        const { rootCID, relativePath } = cidFromPath(ipfsPath)
-
-        if (rootCID) {
-          await ipfs.files.cp(rootCID, tmpDir, {
-            parents: true,
-            cidVersion: 1,
-            signal,
-            timeout: ipfsTimeout
-          })
-        }
-
-        await ipfs.files.rm(posixPath.join(tmpDir, relativePath), {
-          recursive: true,
-          cidVersion: 1,
+          rawLeaves: true,
           signal,
-          timeout: ipfsTimeout
+          timeout
         })
-
-        const { cid } = await ipfs.files.stat(tmpDir, {
-          hash: true,
-          signal,
-          timeout: ipfsTimeout
-        })
-
-        const cidHash = cid.toString()
-        const addedURL = `ipfs://${cidHash}/`
-
-        headers.Location = addedURL
-
-        return {
-          statusCode: 200,
-          headers,
-          data: intoAsyncIterable(addedURL)
-        }
-      } else {
-        return {
-          statusCode: 405,
-          headers,
-          data: intoAsyncIterable('')
-        }
+        toWait.push(result)
       }
-    } catch (e) {
-      const statusCode = (() => {
-        if (e.code === 'ERR_NOT_FOUND') {
-          return 404
-        } else if (e.name === 'TimeoutError') {
-          return 408
-        } else {
-          return 500
-        }
-      })(e)
-      console.error(e.stack)
-      return {
-        statusCode,
-        headers,
-        data: intoAsyncIterable(e.stack)
-      }
+
+      await Promise.all(toWait)
+    } else {
+      const path = posixPath.join(tmpDir, ensureStartingSlash(stripEndingSlash(relativePath)))
+
+      await ipfs.files.write(path, await response.blob(), {
+        signal,
+        parents: true,
+        truncate: true,
+        create: true,
+        rawLeaves: true,
+        cidVersion: 1,
+        timeout
+      })
     }
-  })
-}
 
-async function * intoAsyncIterable (data) {
-  yield Buffer.from(data)
+    const { cid } = await ipfs.files.stat(tmpDir, { hash: true, signal, timeout })
+
+    const cidHash = cid.toString()
+    const endPath = isFormData ? relativePath : stripEndingSlash(relativePath)
+    const addedURL = `ipfs://${cidHash}${ensureStartingSlash(endPath)}`
+
+    return addedURL
+  }
+
+  async function getNode (cid) {
+    const { value } = await ipfs.dag.get(cid, {
+      timeout
+    })
+    return value
+  }
+
+  return fetch
 }
 
 async function collect (iterable) {
@@ -757,12 +785,6 @@ async function collect (iterable) {
   }
 
   return result
-}
-
-async function collectString (iterable) {
-  const items = await collect(iterable)
-
-  return items.map((item) => item.toString()).join('')
 }
 
 function ensureStartingSlash (path) {
@@ -793,6 +815,7 @@ function makeTmpDir () {
 
 function cidFromPath (path) {
   const components = path.split('/')
+  if (path.startsWith('/ipfs/')) components.shift()
   if (path.startsWith('/')) components.shift()
   try {
     const cidComponent = components[0]
@@ -802,7 +825,7 @@ function cidFromPath (path) {
       rootCID,
       relativePath
     }
-  } catch {
+  } catch (e) {
     return {
       rootCID: null,
       relativePath: path
@@ -813,4 +836,13 @@ function cidFromPath (path) {
 function keyToURL ({ id }) {
   const hostname = CID.parse(id, bases).toV1().toString(base36)
   return `ipns://${hostname}/`
+}
+
+function urlToIPFSPath (url) {
+  const { pathname, hostname } = new URL(url)
+  return `/ipfs/${hostname}${pathname}`
+}
+function urlToIPNSPath (url) {
+  const { pathname, hostname } = new URL(url)
+  return `/ipns/${hostname}${pathname}`
 }

--- a/index.js
+++ b/index.js
@@ -456,9 +456,15 @@ export default function makeIPFSFetch ({
       return deleteData(ipfsPath, signal)
     })
     router.delete('ipns://*/**', async ({ url, signal }) => {
-      let ipfsPath = urlToIPFSPath(url)
-      ipfsPath = await resolveIPNS(ipfsPath, signal)
-      return deleteData(ipfsPath, signal)
+      const { hostname: keyName } = new URL(url)
+
+      const ipnsPath = urlToIPNSPath(url)
+      const ipfsPath = await resolveIPNS(ipnsPath, signal)
+      const { body: updatedURL } = await deleteData(ipfsPath, signal)
+
+      const value = updatedURL.replace(/^ipfs:\/\//, '/ipfs/').replace(/^ipns:\/\//, '/ipns/')
+
+      return updateIPNS(keyName, value, signal)
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -31,21 +31,22 @@
     "event-iterator": "^2.0.0",
     "ipfs-unixfs-exporter": "^7.0.6",
     "js-ipld-url": "^1.0.2",
-    "js-ipld-url-resolve": "^1.0.0",
-    "make-fetch": "^3.0.0",
+    "js-ipld-url-resolve": "^1.1.2",
+    "make-fetch": "^3.1.1",
     "mime": "^2.4.6",
     "multiformats": "^9.4.2",
     "range-parser": "^1.2.1"
   },
   "devDependencies": {
-    "@rangermauve/fetch-event-source": "^1.0.1",
+    "@rangermauve/fetch-event-source": "^1.0.3",
     "browser-run": "^8.0.0",
     "browserify": "^17.0.0",
     "form-data": "^4.0.0",
-    "go-ipfs": "^0.12.0",
+    "get-port": "^6.1.2",
+    "go-ipfs": "^0.17.0",
     "ipfs-core": "^0.9.1",
-    "ipfs-http-client": "^56.0.3",
-    "ipfsd-ctl": "^10.0.6",
+    "ipfs-http-client": "^60.0.0",
+    "ipfsd-ctl": "^13.0.0",
     "standard": "^14.3.4",
     "tape": "^5.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "js-ipfs-fetch",
   "version": "4.2.3",
   "description": "Use the same `fetch()` API browsers provide for HTTP, but for IPFS",
-  "main": "index.js",
+  "type": "module",
   "scripts": {
     "lint": "standard --fix",
     "test": "node test",
@@ -31,7 +31,8 @@
     "event-iterator": "^2.0.0",
     "ipfs-unixfs-exporter": "^7.0.6",
     "js-ipld-url": "^1.0.2",
-    "make-fetch": "^2.3.4",
+    "js-ipld-url-resolve": "^1.0.0",
+    "make-fetch": "^3.0.0",
     "mime": "^2.4.6",
     "multiformats": "^9.4.2",
     "range-parser": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ipfs-unixfs-exporter": "^7.0.6",
     "js-ipld-url": "^1.0.2",
     "js-ipld-url-resolve": "^1.1.2",
-    "make-fetch": "^3.1.1",
+    "make-fetch": "^3.1.2",
     "mime": "^2.4.6",
     "multiformats": "^9.4.2",
     "range-parser": "^1.2.1"

--- a/test.js
+++ b/test.js
@@ -936,7 +936,7 @@ test('DELETE from IPFS URL', async (t) => {
   }
 })
 
-test.only('DELETE from IPFS URL', async (t) => {
+test('DELETE from IPFS URL', async (t) => {
   let ipfs = null
   try {
     ipfs = await getInstance()

--- a/test.js
+++ b/test.js
@@ -515,7 +515,7 @@ test('PUT a file and overwrite it', async (t) => {
   }
 })
 
-test('PUT formdata to IPFS cid', async (t) => {
+test.only('PUT formdata to IPFS cid', async (t) => {
   let ipfs = null
   try {
     ipfs = await getInstance()
@@ -526,13 +526,9 @@ test('PUT formdata to IPFS cid', async (t) => {
 
     const form = new FormData()
 
-    form.append('file', new Blob([TEST_DATA]), {
-      filename: 'example.txt'
-    })
+    form.append('file', new Blob([TEST_DATA]), 'example.txt')
 
-    form.append('file', new Blob([TEST_DATA]), {
-      filename: 'example2.txt'
-    })
+    form.append('file', new Blob([TEST_DATA]), 'example2.txt')
 
     const response = await fetch(EMPTY_DIR_URL, {
       method: 'put',
@@ -573,13 +569,9 @@ test('POST formdata to IPFS localhost', async (t) => {
 
     const form = new FormData()
 
-    form.append('file', new Blob([TEST_DATA]), {
-      filename: 'example.txt'
-    })
+    form.append('file', new Blob([TEST_DATA]), 'example.txt')
 
-    form.append('file', new Blob([TEST_DATA]), {
-      filename: 'example2.txt'
-    })
+    form.append('file', new Blob([TEST_DATA]), 'example2.txt')
 
     const body = form.getBuffer()
     const headers = form.getHeaders()
@@ -704,7 +696,7 @@ test('POST a CAR to localhost', async (t) => {
   }
 })
 
-test.only('Publish and resolve IPNS', async (t) => {
+test('Publish and resolve IPNS', async (t) => {
   let ipfs = null
   try {
     ipfs = await getInstance()
@@ -783,13 +775,9 @@ test('PUT FormData to IPNS', async (t) => {
 
     const form = new FormData()
 
-    form.append('file', TEST_DATA, {
-      filename: 'example.txt'
-    })
+    form.append('file', TEST_DATA, 'example.txt')
 
-    form.append('file', TEST_DATA, {
-      filename: 'example2.txt'
-    })
+    form.append('file', TEST_DATA, 'example2.txt')
 
     const body = form.getBuffer()
     const headers = form.getHeaders()


### PR DESCRIPTION
- Rewritten in ESM with latest make-fetch
- `ipld://` URLs can now use IPLD schema CIDs to be applied as lenses
- New `PATCH ipld://` method to make updates to IPLD URLs that might be deeply nested
- Made tests more reliable